### PR TITLE
Make it possible to detect a signature in the next line of a quotation

### DIFF
--- a/lib/email_reply_parser.rb
+++ b/lib/email_reply_parser.rb
@@ -159,7 +159,7 @@ class EmailReplyParser
 
       # Mark the current Fragment as a signature if the current line is empty
       # and the Fragment starts with a common signature indicator.
-      if @fragment && line == EMPTY
+      if @fragment && (is_quoted || line == EMPTY)
         if SIG_REGEX.match @fragment.lines.last
           @fragment.signature = true
           finish_fragment

--- a/test/email_reply_parser_test.rb
+++ b/test/email_reply_parser_test.rb
@@ -180,6 +180,15 @@ I am currently using the Java HTTP API.\n", reply.fragments[0].to_s
     assert_equal "Here is another email\n\nSent from my desk, is much easier then my mobile phone.", EmailReplyParser.parse_reply(body)
   end
 
+  def test_parse_sent_from_inbox
+    reply = email(:email_sent_from_inbox)
+    assert_equal [false, false, true],
+      reply.fragments.map { |f| f.signature? }
+    assert_equal [false, true, true],
+      reply.fragments.map { |f| f.hidden? }
+    assert_equal "Hi,\nThis is a test reply from Inbox.", reply.visible_text
+  end
+
   def test_retains_bullets
     body = IO.read EMAIL_FIXTURE_PATH.join("email_bullets.txt").to_s
     assert_equal "test 2 this should list second\n\nand have spaces\n\nand retain this formatting\n\n\n   - how about bullets\n   - and another",

--- a/test/emails/email_sent_from_inbox.txt
+++ b/test/emails/email_sent_from_inbox.txt
@@ -1,0 +1,13 @@
+Hi,
+This is a test reply from Inbox.
+
+On Wed, May 25, 2016 at 3:13 PM <notifications@github.com> wrote:
+
+> LGTM
+>
+> —
+> You are receiving this because you authored the thread.
+> Reply to this email directly or view it on GitHub
+>
+--
+Hey there, this is my signature


### PR DESCRIPTION
In a reply sent by Google Inbox, there is no empty lines
between its quotation and its signature.
This commit make it possible to detect signatures of such emails.